### PR TITLE
chore: make states consistent in .json snippets

### DIFF
--- a/specifications/negotiation/contract.negotiation.binding.https.md
+++ b/specifications/negotiation/contract.negotiation.binding.https.md
@@ -57,9 +57,11 @@ the [ContractNegotiation](./message/contract.negotiation.json):
   },
   "@type": "ids:ContractNegotiation"
   "@id": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
-  "ids:state" :"consumer_requested"
+  "ids:state" :"idsc:CONSUMER_REQUESTED"
 }  
 ```
+
+Predefined states are: `idsc:CONSUMER_REQUESTED`, `idsc:PROVIDER_OFFERED`, `idsc:CONSUMER_AGREED`, `idsc:PROVIDER_AGREED`, `idsc:CONSUMER_VERIFIED`, `PROVIDER_FINALIZED`, and `idsc:TERMINATED`.
 
 If the negotiation does not exist or the client is not authorized, the provider connector must return an HTTP 404 (Not Found) response.
 
@@ -107,7 +109,7 @@ Location: /negotiations/urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3
   },
   "@type": "ids:ContractNegotiation"
   "@id": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
-  "ids:state" :"consumer_requested"
+  "ids:state" :"idsc:CONSUMER_REQUESTED"
 }
 ```
 

--- a/specifications/negotiation/message/contract.negotiation.json
+++ b/specifications/negotiation/message/contract.negotiation.json
@@ -4,6 +4,6 @@
   },
   "@id": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
   "@type": "ids:ContractNegotiation",
-  "state": "OFFER_REQUESTED",
+  "state": "idsc:CONSUMER_REQUESTED",
   "checksum": "..."
 }

--- a/specifications/transfer/message/transfer.process.json
+++ b/specifications/transfer/message/transfer.process.json
@@ -5,5 +5,5 @@
   "@id": "urn:uuid:71f8dfab-9337-4e9d-a4c7-524e04443f16",
   "@type": "ids:TransferProcess",
   "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
-  "state": "REQUESTED"
+  "state": "idsc:REQUESTED"
 }

--- a/specifications/transfer/transfer.process.binding.https.md
+++ b/specifications/transfer/transfer.process.binding.https.md
@@ -59,9 +59,11 @@ the [TransferProcess](./message/transfer.process.json):
   "@id": "urn:uuid:71f8dfab-9337-4e9d-a4c7-524e04443f16",
   "@type": "ids:TransferProcess",
   "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
-  "state": "REQUESTED"
+  "state": "idsc:REQUESTED"
 } 
 ```
+
+Predefined states are: `idsc:REQUESTED`, `idsc:STARTED`, `idsc:SUSPENDED`, `idsc:REQUESTED`, `idsc:COMPLETED`, and `idsc:TERMINATED`.
 
 If the transfer process does not exist or the client is not authorized, the provider connector must return an HTTP 404 (Not Found) response.
 
@@ -112,7 +114,7 @@ the [TransferProcess](./message/transfer.process.json) message:
   "@id": "urn:uuid:71f8dfab-9337-4e9d-a4c7-524e04443f16",
   "@type": "ids:TransferProcess",
   "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
-  "state": "REQUESTED"
+  "state": "idsc:REQUESTED"
 }
 
  ```


### PR DESCRIPTION
As suggested in #4, IDS specific (introduced) values should have the prefix `idsc:`. I am not an ontology expert, but shouldn't this also go for the states then?

- Aligned naming in .json snippets
- Replaced leftover `offer_requested` by `consumer_requested`
- Added a sentence to both binding documents about the predefined states