### PR TITLE
chore: align process id attribute names

### DIFF
--- a/specifications/negotiation/contract.negotiation.binding.https.md
+++ b/specifications/negotiation/contract.negotiation.binding.https.md
@@ -22,7 +22,7 @@ a [ContractNegotiationErrorMessage](./message/contract.negotiation.error.message
 
 | Field         | Type          | Description                                                 |
 |---------------|---------------|-------------------------------------------------------------|
-| negotiationId | UUID          | The contract negotiation unique id.                         |
+| processId     | UUID          | The contract negotiation unique id.                         |
 | code          | string        | An optional implementation-specific error code.             |
 | reasons       | Array[object] | An optional array of implementation-specific error objects. |
 
@@ -132,7 +132,7 @@ Authorization: ...
     "odrl": "https://www.w3.org/TR/odrl-model"
   },
   "@type": "ids:ContractRequestMessage",
-  "ids:negotiationId": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
+  "ids:processId": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
   "offer": {
     "@type": "odrl:Offer",
     "uid": "...",
@@ -142,7 +142,7 @@ Authorization: ...
 }
 ```
 
-The consumer must include the `negotiationId`. The consumer must include either the `offer` or `offerId` property.
+The consumer must include the `processId`. The consumer must include either the `offer` or `offerId` property.
 
 If the message is successfully processed, the provider connector must return and HTTP 200 (OK) response. The response body is not specified and clients are not required to process
 it.
@@ -175,7 +175,7 @@ Authorization: ...
     "odrl": "https://www.w3.org/TR/odrl-model"
   },
   "@type": "ids:ContractAgreementVerificationMessage",
-  "negotiationId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
   "ids:consumerSignature": {
     "timestamp": 121212,
     "hash": "....",
@@ -217,7 +217,7 @@ Authorization: ...
     "odrl": "https://www.w3.org/TR/odrl-model"
   },
   "@type": "ids:ContractOfferMessage",
-  "ids:negotiationId": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
+  "ids:processId": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
   "offer": {
     "@type": "odrl:Offer",
     "uid": "...",
@@ -248,7 +248,7 @@ Authorization: ...
     "odrl": "https://www.w3.org/TR/odrl-model"
   },
   "@type": "ids:ContractAgreementMessage",
-  "negotiationId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
   "odrl:agreement": {
     "@type": "odrl:Agreement",
     "uid": "e8dc8655-44c2-46ef-b701-4cffdc2faa44",

--- a/specifications/negotiation/contract.negotiation.protocol.md
+++ b/specifications/negotiation/contract.negotiation.protocol.md
@@ -68,9 +68,9 @@ The _ContractRequestMessage_ is sent by a consumer to initiate a contract negoti
 
 #### Notes
 
-- The consumer must include either an `offer` or `offerId` property. If the message includes a `negotiationId` property, the request will be associated with an existing contract
-  negotiation and a consumer offer will be created using either the `offer` or `offerId` properties. If the message does not include a `negotiationId`, a new contract negotiation
-  will be created using either the `offer` or `offerId` properties and the provider selects an appropriate `negotiationId`.
+- The consumer must include either an `offer` or `offerId` property. If the message includes a `processId` property, the request will be associated with an existing contract
+  negotiation and a consumer offer will be created using either the `offer` or `offerId` properties. If the message does not include a `processId`, a new contract negotiation
+  will be created using either the `offer` or `offerId` properties and the provider selects an appropriate `processId`.
 
 - It is an error to include both an `offer` and `offerId` property.
 

--- a/specifications/negotiation/contract.negotiation.protocol.md
+++ b/specifications/negotiation/contract.negotiation.protocol.md
@@ -99,7 +99,7 @@ The _ContractRequestMessage_ is sent by a consumer to initiate a contract negoti
 
 The _ContractAgreementMessage_ is sent by a provider when it agrees to a contract. It contains the complete contract agreement with the provider's signature.
 
-A _ContractAgreementMessage_ must contain a `negotiationId`.
+A _ContractAgreementMessage_ must contain a `processId`.
 
 A _ContractAgreementMessage_ must contain a the ODRL Agreement as the credential subject and the provider signature as the proof.
 
@@ -124,7 +124,7 @@ A _ContractAgreementMessage_ must contain a hash value of the credential subject
 The _ContractAgreementVerificationMessage_ is sent by a consumer to verify the acceptance of a contract agreement. It contains the hash of the contract agreement and the provider's signature as the credential subject and the consumer signature as the proof.
 A provider responds with an error if the signature can't be validated or is incorrect.
 
-A _ContractAgreementVerificationMessage_ must contain a `negotiationId`.
+A _ContractAgreementVerificationMessage_ must contain a `processId`.
 
 ### 4. ContractNegotiationEventMessage
 

--- a/specifications/negotiation/message/contract.agreement.message.http.dataplane.json
+++ b/specifications/negotiation/message/contract.agreement.message.http.dataplane.json
@@ -2,17 +2,17 @@
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "some-id",
   "@type": [ "cred:VerifiableCredential", "ids:ContractAgreementMessage"],
-  "ids:negotiationId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "ids:processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
   "cred:issuer": { "@id": "http://provider.com/edc" },
-  "cred:issuanceDate": { 
+  "cred:issuanceDate": {
     "@type": "xsd:dateTime",
     "@value": "2022-11-18T13:00:00.000Z"
   },
   "cred:credentialSubject": {
-    
+
     "@type": [ "cred:VerifiableCredential", "ids:ConsumerSignedAgreement"],
     "cred:issuer": { "@id": "http://consumer.com/edc" },
-    "cred:issuanceDate": { 
+    "cred:issuanceDate": {
       "@type": "xsd:dateTime",
       "@value": "2022-11-18T12:00:00.000Z"
     },
@@ -45,7 +45,7 @@
     },
     "sec:proof": {
         "@type": "sec:Ed25519Signature2018",
-        "dct:created": { 
+        "dct:created": {
           "@type": "xsd:dateTime",
           "@value": "2022-11-18T12:00:01Z"
         },
@@ -56,7 +56,7 @@
   },
   "sec:proof": {
       "@type": "sec:Ed25519Signature2018",
-      "dct:created":{ 
+      "dct:created":{
         "@type": "xsd:dateTime",
         "@value": "2022-11-18T13:00:01Z"
       },

--- a/specifications/negotiation/message/contract.agreement.message.json
+++ b/specifications/negotiation/message/contract.agreement.message.json
@@ -1,7 +1,7 @@
 {
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:ContractAgreementMessage",
-  "ids:negotiationId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "ids:processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
   "cred:credentialSubject": {
     "@type": "odrl:Agreement",
     "@id": "e8dc8655-44c2-46ef-b701-4cffdc2faa44",
@@ -10,7 +10,7 @@
     }
   },
   "sec:proof": {
-    "dct:created": { 
+    "dct:created": {
       "@type": "xsd:dateTime",
       "@value": "2022-11-18T12:00:01Z"
     },

--- a/specifications/negotiation/message/contract.agreement.verification.message.json
+++ b/specifications/negotiation/message/contract.agreement.verification.message.json
@@ -1,14 +1,14 @@
 {
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:ContractAgreementVerificationMessage",
-  "ids:negotiationId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
-  "cred:subject": { 
+  "ids:processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "cred:subject": {
     "@type": "ids:ContractAgreementMessage",
     "ids:hash": "123abc456efgh"
   },
   "sec:proof": {
     "@type": "sec:Ed25519Signature2018",
-    "dct:created": { 
+    "dct:created": {
       "@type": "xsd:dateTime",
       "@value": "2022-11-18T12:00:01Z"
     },

--- a/specifications/negotiation/message/contract.negotiation.error.message.json
+++ b/specifications/negotiation/message/contract.negotiation.error.message.json
@@ -1,7 +1,7 @@
 {
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:ContractNegotiationErrorMessage",
-  "ids:negotiationId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "ids:processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
   "ids:code": "...",
   "ids:reasons": [
     {},

--- a/specifications/negotiation/message/contract.negotiation.event.message.json
+++ b/specifications/negotiation/message/contract.negotiation.event.message.json
@@ -3,7 +3,7 @@
     "ids": "https://idsa.org/"
   },
   "@type": "ids:ContractNegotiationEventMessage",
-  "negotiationId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
   "eventType": "accepted | finalized",
   "checksum": "..."
 }

--- a/specifications/negotiation/message/contract.negotiation.termination.message.json
+++ b/specifications/negotiation/message/contract.negotiation.termination.message.json
@@ -3,7 +3,7 @@
     "ids": "https://idsa.org/"
   },
   "@type": "ids:ContractNegotiationTermination",
-  "negotiationId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
   "code": "...",
   "reasons": [
     {},

--- a/specifications/negotiation/message/contract.offer.message.json
+++ b/specifications/negotiation/message/contract.offer.message.json
@@ -4,7 +4,7 @@
     "odrl": "https://www.w3.org/TR/odrl-model"
   },
   "@type": "ids:ContractOfferMessage",
-  "ids:negotiationId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "ids:processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
   "offer": {
     "@type": "odrl:Offer",
     "uid": "...",

--- a/specifications/negotiation/message/contract.request.message.json
+++ b/specifications/negotiation/message/contract.request.message.json
@@ -3,7 +3,7 @@
   "@id": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
   "@type": "ids:ContractRequestMessage",
   "dataSet": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
-  "ids:negotiationId": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
+  "ids:processId": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
   "ids:offerId": "urn:uuid:2828282:3dd1add8-4d2d-569e-d634-8394a8836a88",
   "ids:offer": {
     "@type": "odrl:Offer",

--- a/specifications/transfer/message/transfer.completion.message.json
+++ b/specifications/transfer/message/transfer.completion.message.json
@@ -2,6 +2,6 @@
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "urn:uuid:6b9dd9cc-f60c-4253-b031-86755cf25720",
   "@type": "ids:TransferCompletionMessage",
-  "transferProcessId": "urn:uuid:24a62493-06eb-45e4-a41c-6de091b51da5",
+  "processId": "urn:uuid:24a62493-06eb-45e4-a41c-6de091b51da5",
   "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f"
 }

--- a/specifications/transfer/message/transfer.error.message.json
+++ b/specifications/transfer/message/transfer.error.message.json
@@ -1,7 +1,7 @@
 {
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:TransferErrorMessage",
-  "transferProcessId": "urn:uuid:71f8dfab-9337-4e9d-a4c7-524e04443f16",
+  "processId": "urn:uuid:71f8dfab-9337-4e9d-a4c7-524e04443f16",
   "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
   "code": "...",
   "reasons": [

--- a/specifications/transfer/message/transfer.start.message.json
+++ b/specifications/transfer/message/transfer.start.message.json
@@ -2,7 +2,7 @@
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "urn:uuid:6b9dd9cc-f60c-4253-b031-86755cf25720",
   "@type": "ids:TransferStartMessage",
-  "transferProcessId": "urn:uuid:24a62493-06eb-45e4-a41c-6de091b51da5",
+  "processId": "urn:uuid:24a62493-06eb-45e4-a41c-6de091b51da5",
   "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
   "dataAddress": {}
 }

--- a/specifications/transfer/message/transfer.suspension.message.json
+++ b/specifications/transfer/message/transfer.suspension.message.json
@@ -2,7 +2,7 @@
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "urn:uuid:6b9dd9cc-f60c-4253-b031-86755cf25720",
   "@type": "ids:TransferSuspensionMessage",
-  "transferProcessId": "urn:uuid:24a62493-06eb-45e4-a41c-6de091b51da5",
+  "processId": "urn:uuid:24a62493-06eb-45e4-a41c-6de091b51da5",
   "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
   "code": "...",
   "reasons": [

--- a/specifications/transfer/message/transfer.termination.message.json
+++ b/specifications/transfer/message/transfer.termination.message.json
@@ -2,7 +2,7 @@
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "urn:uuid:6b9dd9cc-f60c-4253-b031-86755cf25720",
   "@type": "ids:TransferTerminationMessage",
-  "transferProcessId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
   "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
   "code": "...",
   "reasons": [

--- a/specifications/transfer/transfer.process.binding.https.md
+++ b/specifications/transfer/transfer.process.binding.https.md
@@ -22,7 +22,7 @@ a [TransferErrorMessage](./message/transfer.error.message.json) with the followi
 
 | Field             | Type          | Description                                                         |
 |-------------------|---------------|---------------------------------------------------------------------|
-| transferProcessId | UUID          | The transfer process unique id.                                     |
+| processId         | UUID          | The transfer process unique id.                                     |
 | correlationId     | UUID          | The correlation id if sent by the provider; otherwise not included. |
 | code              | string        | An optional implementation-specific error code.                     |
 | reasons           | Array[object] | An optional array of implementation-specific error objects.         |


### PR DESCRIPTION
As negotiation and transfer are both processes, why not simplify the id attribute naming and call it `processId`. As the message names are unique, this will not cause any problems. Moreover, it could provide benefits on an implementation level (maybe). WDYT?

Note: The `transferProcessId` in general was a leftover. Even without this renaming, it should be called `transferId` to be aligned with the shortened message names.