### PR TITLE
fix: add missing ids prefixes and shortened context information

### DIFF
--- a/specifications/catalog/catalog.binding.https.md
+++ b/specifications/catalog/catalog.binding.https.md
@@ -36,9 +36,7 @@ POST https://provider.com/catalog/request
 Authorization: ...
 
 {
-  "@context": {
-    "ids": "https://idsa.org/"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:CatalogRequest"
   "ids:filter": {}
 }
@@ -74,9 +72,7 @@ and the HTTP `Link` header. The `Link` header will contain URLs for navigating t
 ```
 Link: <https://provider.com/catalog?page=2&per_page=100>; rel="next"
 {
-  "@context": {
-    "dcat": "http://www.w3.org/ns/dcat/"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "dcat:Catalog"
   ...
 }
@@ -123,7 +119,7 @@ POST https://provider.com/catalog/request
 Authorization: ...
 
 {
-  "@context:{},
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:CatalogRequest"
   "@id: "..."
   "ids:callbackAddress": "https://example.com/endpoint"

--- a/specifications/catalog/message/catalog.error.message.json
+++ b/specifications/catalog/message/catalog.error.message.json
@@ -1,8 +1,8 @@
 {
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:CatalogErrorMessage",
-  "code": "123:A",
-  "reasons": [
+  "ids:code": "123:A",
+  "ids:reasons": [
     {},
     {}
   ]

--- a/specifications/negotiation/contract.negotiation.binding.https.md
+++ b/specifications/negotiation/contract.negotiation.binding.https.md
@@ -52,9 +52,7 @@ the [ContractNegotiation](./message/contract.negotiation.json):
 
 ```
 {
-  "@context": {
-    "ids": "https://idsa.org/"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:ContractNegotiation"
   "@id": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
   "ids:state" :"idsc:CONSUMER_REQUESTED"
@@ -78,14 +76,12 @@ POST https://connector.provider.com/negotiations/request
 Authorization: ...
 
 {
-  "@context": {
-    "ids": "https://idsa.org/"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:ContractRequest"
   "@id": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
-  "dataSet": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
-  "offerId": "urn:uuid:2828282:3dd1add8-4d2d-569e-d634-8394a8836a88",
-  "callbackAddress": "https://......"
+  "ids:dataSet": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
+  "ids:offerId": "urn:uuid:2828282:3dd1add8-4d2d-569e-d634-8394a8836a88",
+  "ids:callbackAddress": "https://......"
 }
 ```
 
@@ -104,9 +100,7 @@ the [ContractNegotiation](./message/contract.negotiation.json) message:
 Location: /negotiations/urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3
 
 {
-  "@context": {
-    "ids": "https://idsa.org/"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:ContractNegotiation"
   "@id": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
   "ids:state" :"idsc:CONSUMER_REQUESTED"
@@ -127,18 +121,15 @@ POST https://connector.provider.com/negotiations/urn:uuid:dcbf434c-eacf-4582-9a0
 Authorization: ...
 
 {
-  "@context": {
-    "ids": "https://idsa.org/",
-    "odrl": "https://www.w3.org/TR/odrl-model"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:ContractRequestMessage",
   "ids:processId": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
-  "offer": {
+  "ids:offer": {
     "@type": "odrl:Offer",
     "uid": "...",
     "target": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88"
   },
-  "checksum": "..."
+  "ids:checksum": "..."
 }
 ```
 
@@ -170,12 +161,9 @@ POST https://connector.provider.com/negotiations/urn:uuid:a343fcbf-99fc-4ce8-8e9
 Authorization: ...
 
 {
-  "@context": {
-    "ids": "https://idsa.org/",
-    "odrl": "https://www.w3.org/TR/odrl-model"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:ContractAgreementVerificationMessage",
-  "processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "ids:processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
   "ids:consumerSignature": {
     "timestamp": 121212,
     "hash": "....",
@@ -212,18 +200,15 @@ POST https://connector.consumer.com/callback/negotiations/urn:uuid:dcbf434c-eacf
 Authorization: ...
 
 {
-  "@context": {
-    "ids": "https://idsa.org/",
-    "odrl": "https://www.w3.org/TR/odrl-model"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:ContractOfferMessage",
   "ids:processId": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
-  "offer": {
+  "ids:offer": {
     "@type": "odrl:Offer",
     "uid": "...",
     "target": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88"
   },
-  "checksum": "..."
+  "ids:checksum": "..."
 }
 ```
 
@@ -243,13 +228,10 @@ POST https://connector.consumer.com/negotiations/urn:uuid:a343fcbf-99fc-4ce8-8e9
 Authorization: ...
 
 {
-  "@context": {
-    "ids": "https://idsa.org/",
-    "odrl": "https://www.w3.org/TR/odrl-model"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:ContractAgreementMessage",
-  "processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
-  "odrl:agreement": {
+  "ids:processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "ids:agreement": {
     "@type": "odrl:Agreement",
     "uid": "e8dc8655-44c2-46ef-b701-4cffdc2faa44",
     "ids:providerSignature": {
@@ -258,7 +240,7 @@ Authorization: ...
       "signature": "..."
     }
   },
-  "checksum": "..."
+  "ids:checksum": "..."
 }
 ```
 

--- a/specifications/negotiation/message/contract.negotiation.event.message.json
+++ b/specifications/negotiation/message/contract.negotiation.event.message.json
@@ -1,9 +1,7 @@
 {
-  "@context": {
-    "ids": "https://idsa.org/"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:ContractNegotiationEventMessage",
-  "processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
-  "eventType": "accepted | finalized",
-  "checksum": "..."
+  "ids:processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "ids:eventType": "accepted | finalized",
+  "ids:checksum": "..."
 }

--- a/specifications/negotiation/message/contract.negotiation.json
+++ b/specifications/negotiation/message/contract.negotiation.json
@@ -1,9 +1,7 @@
 {
-  "@context": {
-    "ids": "https://idsa.org/"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
   "@type": "ids:ContractNegotiation",
-  "state": "idsc:CONSUMER_REQUESTED",
-  "checksum": "..."
+  "ids:state": "idsc:CONSUMER_REQUESTED",
+  "ids:checksum": "..."
 }

--- a/specifications/negotiation/message/contract.negotiation.termination.message.json
+++ b/specifications/negotiation/message/contract.negotiation.termination.message.json
@@ -1,11 +1,9 @@
 {
-  "@context": {
-    "ids": "https://idsa.org/"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:ContractNegotiationTermination",
-  "processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
-  "code": "...",
-  "reasons": [
+  "ids:processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "ids:code": "...",
+  "ids:reasons": [
     {},
     {}
   ]

--- a/specifications/negotiation/message/contract.offer.message.json
+++ b/specifications/negotiation/message/contract.offer.message.json
@@ -1,14 +1,11 @@
 {
-  "@context": {
-    "ids": "https://idsa.org/",
-    "odrl": "https://www.w3.org/TR/odrl-model"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:ContractOfferMessage",
   "ids:processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
-  "offer": {
+  "ids:offer": {
     "@type": "odrl:Offer",
     "uid": "...",
     "target": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88"
   },
-  "checksum": "..."
+  "ids:checksum": "..."
 }

--- a/specifications/transfer/message/transfer.completion.message.json
+++ b/specifications/transfer/message/transfer.completion.message.json
@@ -2,6 +2,6 @@
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "urn:uuid:6b9dd9cc-f60c-4253-b031-86755cf25720",
   "@type": "ids:TransferCompletionMessage",
-  "processId": "urn:uuid:24a62493-06eb-45e4-a41c-6de091b51da5",
-  "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f"
+  "ids:processId": "urn:uuid:24a62493-06eb-45e4-a41c-6de091b51da5",
+  "ids:correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f"
 }

--- a/specifications/transfer/message/transfer.error.message.json
+++ b/specifications/transfer/message/transfer.error.message.json
@@ -1,10 +1,10 @@
 {
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@type": "ids:TransferErrorMessage",
-  "processId": "urn:uuid:71f8dfab-9337-4e9d-a4c7-524e04443f16",
-  "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
-  "code": "...",
-  "reasons": [
+  "ids:processId": "urn:uuid:71f8dfab-9337-4e9d-a4c7-524e04443f16",
+  "ids:correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
+  "ids:code": "...",
+  "ids:reasons": [
     {},
     {}
   ]

--- a/specifications/transfer/message/transfer.process.json
+++ b/specifications/transfer/message/transfer.process.json
@@ -2,6 +2,6 @@
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "urn:uuid:71f8dfab-9337-4e9d-a4c7-524e04443f16",
   "@type": "ids:TransferProcess",
-  "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
-  "state": "idsc:REQUESTED"
+  "ids:correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
+  "ids:state": "idsc:REQUESTED"
 }

--- a/specifications/transfer/message/transfer.request.message.json
+++ b/specifications/transfer/message/transfer.request.message.json
@@ -2,8 +2,8 @@
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
   "@type": "ids:TransferRequestMessage",
-  "agreementId": "urn:uuid:e8dc8655-44c2-46ef-b701-4cffdc2faa44",
+  "ids:agreementId": "urn:uuid:e8dc8655-44c2-46ef-b701-4cffdc2faa44",
   "dct:format": "ids:s3+push",
-  "dataAddress": {},
-  "callbackAddress": "https://......"
+  "ids:dataAddress": {},
+  "ids:callbackAddress": "https://......"
 }

--- a/specifications/transfer/message/transfer.start.message.json
+++ b/specifications/transfer/message/transfer.start.message.json
@@ -2,7 +2,7 @@
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "urn:uuid:6b9dd9cc-f60c-4253-b031-86755cf25720",
   "@type": "ids:TransferStartMessage",
-  "processId": "urn:uuid:24a62493-06eb-45e4-a41c-6de091b51da5",
-  "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
-  "dataAddress": {}
+  "ids:processId": "urn:uuid:24a62493-06eb-45e4-a41c-6de091b51da5",
+  "ids:correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
+  "ids:dataAddress": {}
 }

--- a/specifications/transfer/message/transfer.suspension.message.json
+++ b/specifications/transfer/message/transfer.suspension.message.json
@@ -2,10 +2,10 @@
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "urn:uuid:6b9dd9cc-f60c-4253-b031-86755cf25720",
   "@type": "ids:TransferSuspensionMessage",
-  "processId": "urn:uuid:24a62493-06eb-45e4-a41c-6de091b51da5",
-  "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
-  "code": "...",
-  "reasons": [
+  "ids:processId": "urn:uuid:24a62493-06eb-45e4-a41c-6de091b51da5",
+  "ids:correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
+  "ids:code": "...",
+  "ids:reasons": [
     {},
     {}
   ]

--- a/specifications/transfer/message/transfer.termination.message.json
+++ b/specifications/transfer/message/transfer.termination.message.json
@@ -2,10 +2,10 @@
   "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "urn:uuid:6b9dd9cc-f60c-4253-b031-86755cf25720",
   "@type": "ids:TransferTerminationMessage",
-  "processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
-  "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
-  "code": "...",
-  "reasons": [
+  "ids:processId": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
+  "ids:correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
+  "ids:code": "...",
+  "ids:reasons": [
     {},
     {}
   ]

--- a/specifications/transfer/transfer.process.binding.https.md
+++ b/specifications/transfer/transfer.process.binding.https.md
@@ -53,13 +53,11 @@ the [TransferProcess](./message/transfer.process.json):
 
 ```
 {
-  "@context": {
-    "ids": "https://idsa.org/"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "urn:uuid:71f8dfab-9337-4e9d-a4c7-524e04443f16",
   "@type": "ids:TransferProcess",
-  "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
-  "state": "idsc:REQUESTED"
+  "ids:correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
+  "ids:state": "idsc:REQUESTED"
 } 
 ```
 
@@ -80,16 +78,13 @@ to `transfer-processes/request`:
  Authorization: ...
  
 {
-  "@context": {
-    "ids": "https://idsa.org/",
-    "dct": "dct:"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
   "@type": "ids:TransferRequestMessage",
-  "agreementId": "urn:uuid:e8dc8655-44c2-46ef-b701-4cffdc2faa44",
+  "ids:agreementId": "urn:uuid:e8dc8655-44c2-46ef-b701-4cffdc2faa44",
   "dct:format": "ids:s3+push",
   "dataAddress": {},
-  "callbackAddress": "https://......"
+  "ids:callbackAddress": "https://......"
 }
  ```
 
@@ -108,13 +103,11 @@ the [TransferProcess](./message/transfer.process.json) message:
  Location: /transfer-processes/urn:uuid:71f8dfab-9337-4e9d-a4c7-524e04443f16
  
 {
-  "@context": {
-    "ids": "https://idsa.org/"
-  },
+  "@context":  "https://w3id.org/idsa/v5/context.json",
   "@id": "urn:uuid:71f8dfab-9337-4e9d-a4c7-524e04443f16",
   "@type": "ids:TransferProcess",
-  "correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
-  "state": "idsc:REQUESTED"
+  "ids:correlationId": "urn:uuid:4a3ad65e-d78a-4200-a666-fc47aec32f2f",
+  "ids:state": "idsc:REQUESTED"
 }
 
  ```


### PR DESCRIPTION
- Replaced leftover contexts with the shortened `"@context":  "https://w3id.org/idsa/v5/context.json",`
- Added missing `ids` prefixes